### PR TITLE
Removing extraneous debug logging

### DIFF
--- a/location_hijacking.rb
+++ b/location_hijacking.rb
@@ -41,8 +41,7 @@ class LocationHijacking < BetterCap::Proxy::Module
           end
         end
       end
-      BetterCap::Logger.info request.url
-      BetterCap::Logger.info request.host
+
       if !found && !@@location.include?(request.host)
         BetterCap::Logger.info "No Location header found, adding one now for #{@@location}"
         # Replace HTTP Response code with 302


### PR DESCRIPTION
Two log statements used during debugging were
accidentally left in the source.  This commit
removes them.

Sorry about that!