### PR TITLE
Improve osxsparkle error message when ftpd is missing

### DIFF
--- a/osxsparkle.rb
+++ b/osxsparkle.rb
@@ -13,8 +13,12 @@ This project is released under the GPL 3 license.
 require 'time'
 require 'net/http'
 require 'uri'
-require 'ftpd'
 require 'tmpdir'
+begin
+  require 'ftpd'
+rescue LoadError
+  raise BetterCap::Error, "You need to install the 'ftpd' gem for this module to work."
+end
 
 # Driver class for FTPd
 class Driver


### PR DESCRIPTION
`BetterCap::Proxy::Module.load` [assumes][link] that any `LoadError` is caused by the module itself not being found. With `ftpd` missing, you would therefore get an error about `osxsparkle` being an invalid module name.

Maybe the error handling upstream could also be tweaked to avoid this confusion. If you have any thoughts on what that could look like, I'd be happy to contribute.

  [link]: https://github.com/evilsocket/bettercap/blob/v1.3.3/lib/bettercap/proxy/module.rb#L51-L57