### PR TITLE
Added 'Content-Type' header

### DIFF
--- a/http/replace_file.rb
+++ b/http/replace_file.rb
@@ -42,7 +42,7 @@ class ReplaceFile < BetterCap::Proxy::HTTP::Module
   def on_request( request, response )
     if request.path.include?(".#{@@extension}")
       BetterCap::Logger.info "Replacing http://#{request.host}#{request.path} with #{@@filename}."
-
+      response['Content-Type'] = "application/octet-stream"
       response['Content-Length'] = @@payload.bytesize
       response.body = @@payload
     end


### PR DESCRIPTION
Added 'Content-Type' header so browsers could easily understand the payload type if it is "application/octet-stream" hence downloaded properly instead of displaying the content.

I suggest also automatically checking the requested file's extension then set the "Content-Type" header value to the appropriate one.