### PR TITLE
Changed @imgArray.pop to @imgArray.shift

### DIFF
--- a/http/replace_images.rb
+++ b/http/replace_images.rb
@@ -21,8 +21,8 @@ class ReplaceImages < BetterCap::Proxy::HTTP::Module
 	def initialize
 		opts = BetterCap::Context.get.options.servers
 		@imgArray = Dir.entries("#{opts.httpd_path}")
-		@imgArray.pop
-		@imgArray.pop
+		@imgArray.shift
+		@imgArray.shift
 		# make sure the server is running
 		raise BetterCap::Error, "The ReplaceImages proxy module needs the HTTPD ( --httpd argument ) running."	unless opts.httpd
 		# make sure the file we need actually exists  


### PR DESCRIPTION
`@imgArray.pop` does not delete the "." and ".." files from the array but cuts it from the other side which made the module unusable since (when supplying less than 3 images) it would just replace images on a site with `<httpdServer>/.` or `<httpdServer>/..`. `@imgArray.shift` fixes this.